### PR TITLE
Added feature to show presence

### DIFF
--- a/Luxa4Slack.Console/CommandLineOptions.cs
+++ b/Luxa4Slack.Console/CommandLineOptions.cs
@@ -7,11 +7,14 @@
     [Option('t', "token", Required = true, SetName = "run", HelpText = "Slack token (use --requesttoken option)")]
     public string Token { get; set; }
 
-    [Option('m', "showUnreadMessages", Default = true, SetName = "run", HelpText = "Show unread messages")]
+    [Option('m', "showUnreadMessages", Default = false, SetName = "run", HelpText = "Show unread messages")]
     public bool ShowUnreadMessages { get; set; }
 
-    [Option('M', "showUnreadMentions", Default = true, SetName = "run", HelpText = "Show unread mentions")]
+    [Option('M', "showUnreadMentions", Default = false, SetName = "run", HelpText = "Show unread mentions")]
     public bool ShowUnreadMentions { get; set; }
+
+    [Option('s', "showStatus", Default = true, SetName = "run", HelpText = "Show status changes")]
+    public bool ShowStatus { get; set; }
 
     [Option('d', "debug", Default = false, SetName = "run", HelpText = "Show debug informations")]
     public bool Debug { get; set; }

--- a/Luxa4Slack.Console/Program.cs
+++ b/Luxa4Slack.Console/Program.cs
@@ -27,7 +27,8 @@
           luxa4Slack = new Luxa4Slack(
             commandLineOptions.Token,
             commandLineOptions.ShowUnreadMentions,
-            commandLineOptions.ShowUnreadMessages);
+            commandLineOptions.ShowUnreadMessages,
+            commandLineOptions.ShowStatus);
 
           try
           {

--- a/Luxa4Slack.Tray/App.xaml.cs
+++ b/Luxa4Slack.Tray/App.xaml.cs
@@ -22,6 +22,8 @@
 
     private bool showUnreadMessages;
 
+    private bool showStatus;
+
     private Luxa4Slack luxa4Slack;
 
     protected override void OnStartup(StartupEventArgs e)
@@ -44,6 +46,7 @@
       this.token = Settings.Default.Token;
       this.showUnreadMentions = Settings.Default.ShowUnreadMentions;
       this.showUnreadMessages = Settings.Default.ShowUnreadMessages;
+      this.showStatus = Settings.Default.ShowStatus;
 
       // Init Luxa4Slack
       Task.Factory.StartNew(this.Initialize);
@@ -66,7 +69,7 @@
       }
       else
       {
-        this.luxa4Slack = new Luxa4Slack(this.token, this.showUnreadMentions, this.showUnreadMessages);
+        this.luxa4Slack = new Luxa4Slack(this.token, this.showUnreadMentions, this.showUnreadMessages, this.showStatus);
         try
         {
           this.luxa4Slack.Initialize();

--- a/Luxa4Slack.Tray/Preferences.xaml
+++ b/Luxa4Slack.Tray/Preferences.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="{Binding Title}"
-        Height="190" Width="420"
+        Height="232.12" Width="420"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterScreen"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -11,42 +11,44 @@
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance local:TrayViewModel}"
         Icon="{Binding Icon}">
-  <Grid Margin="8">
-    <Grid.ColumnDefinitions>
-      <ColumnDefinition Width="Auto" />
-      <ColumnDefinition />
-    </Grid.ColumnDefinitions>
-    <Grid.RowDefinitions>
-      <RowDefinition />
-      <RowDefinition />
-      <RowDefinition />
-      <RowDefinition />
-      <RowDefinition />
-    </Grid.RowDefinitions>
-    
-    <Grid.Resources>
-      <Style TargetType="{x:Type CheckBox}">
-        <Style.Setters>
-          <Setter Property="Margin" Value="0,5" />
-        </Style.Setters>
-      </Style>
-      <Style TargetType="{x:Type TextBlock}">
-        <Style.Setters>
-          <Setter Property="Padding" Value="0,5" />
-        </Style.Setters>
-      </Style>
-    </Grid.Resources>
+    <Grid Margin="8">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition />
+            <RowDefinition />
+            <RowDefinition />
+            <RowDefinition />
+        </Grid.RowDefinitions>
 
-    <TextBlock Grid.Row="0" Grid.Column="0" Text="Slack token: " />
-    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Token}" VerticalAlignment="Center" HorizontalContentAlignment="Stretch" HorizontalAlignment="Stretch" />
+        <Grid.Resources>
+            <Style TargetType="{x:Type CheckBox}">
+                <Style.Setters>
+                    <Setter Property="Margin" Value="0,5" />
+                </Style.Setters>
+            </Style>
+            <Style TargetType="{x:Type TextBlock}">
+                <Style.Setters>
+                    <Setter Property="Padding" Value="0,5" />
+                </Style.Setters>
+            </Style>
+        </Grid.Resources>
 
-    <TextBlock  Margin="0,-5,0,0" VerticalAlignment="Top" HorizontalAlignment="Right" Grid.Row="1" Grid.Column="1">
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Slack token: " />
+        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Token}" VerticalAlignment="Center" HorizontalContentAlignment="Stretch" HorizontalAlignment="Stretch" />
+
+        <TextBlock  Margin="0,-5,0,0" VerticalAlignment="Top" HorizontalAlignment="Right" Grid.Row="1" Grid.Column="1">
         <Hyperlink Command="{Binding RequestTokenCommand}">Request a Slack token</Hyperlink>
-    </TextBlock>
+        </TextBlock>
 
-    <CheckBox Grid.Row="2" Grid.ColumnSpan="2" Content="Show unread messages" IsChecked="{Binding ShowUnreadMentions}" />
-    <CheckBox Grid.Row="3" Grid.ColumnSpan="2" Content="Show unread mentions" IsChecked="{Binding ShowUnreadMessages}" />
+        <CheckBox Grid.Row="2" Grid.ColumnSpan="2" Content="Show unread messages" IsChecked="{Binding ShowUnreadMentions}" />
+        <CheckBox Grid.Row="2" Grid.ColumnSpan="2" Content="Show unread mentions" IsChecked="{Binding ShowUnreadMessages}" Margin="0,25,0,22" Grid.RowSpan="2" />
+        <CheckBox Grid.Row="2" Grid.ColumnSpan="2" Content="Show status" IsChecked="{Binding ShowStatus}" Margin="0,45,0,0" Grid.RowSpan="2"/>
 
-    <Button Grid.Row="4" Grid.ColumnSpan="2" Content="Save and restart" HorizontalAlignment="Center" Height="24" Width="120" Command="{Binding RestartApplicationCommand}" />
-  </Grid>
+
+        <Button Grid.Row="4" Grid.ColumnSpan="2" Content="Save and restart" HorizontalAlignment="Center" Height="24" Width="120" Command="{Binding RestartApplicationCommand}" />
+    </Grid>
 </Window>

--- a/Luxa4Slack.Tray/PreferencesViewModel.cs
+++ b/Luxa4Slack.Tray/PreferencesViewModel.cs
@@ -17,6 +17,7 @@
       this.Token = Properties.Settings.Default.Token;
       this.ShowUnreadMentions = Properties.Settings.Default.ShowUnreadMentions;
       this.ShowUnreadMessages = Properties.Settings.Default.ShowUnreadMessages;
+      this.ShowStatus = Properties.Settings.Default.ShowStatus;
     }
 
     public ICommand RestartApplicationCommand { get; private set; }
@@ -31,11 +32,14 @@
 
     public bool ShowUnreadMessages { get; set; }
 
+    public bool ShowStatus { get; set; }
+
     private void RestartApplication()
     {
       Properties.Settings.Default.Token = this.Token;
       Properties.Settings.Default.ShowUnreadMentions = this.ShowUnreadMentions;
       Properties.Settings.Default.ShowUnreadMessages = this.ShowUnreadMessages;
+      Properties.Settings.Default.ShowStatus = this.ShowStatus;
       Properties.Settings.Default.Save();
 
       Process.Start(Application.ResourceAssembly.Location);

--- a/Luxa4Slack.Tray/Properties/Settings.Designer.cs
+++ b/Luxa4Slack.Tray/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CG.Luxa4Slack.Tray.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.2.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -38,6 +38,30 @@ namespace CG.Luxa4Slack.Tray.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ShouldUpgrade {
+            get {
+                return ((bool)(this["ShouldUpgrade"]));
+            }
+            set {
+                this["ShouldUpgrade"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("true")]
+        public bool ShowStatus {
+            get {
+                return ((bool)(this["ShowStatus"]));
+            }
+            set {
+                this["ShowStatus"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool ShowUnreadMessages {
             get {
                 return ((bool)(this["ShowUnreadMessages"]));
@@ -49,25 +73,13 @@ namespace CG.Luxa4Slack.Tray.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool ShowUnreadMentions {
             get {
                 return ((bool)(this["ShowUnreadMentions"]));
             }
             set {
                 this["ShowUnreadMentions"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool ShouldUpgrade {
-            get {
-                return ((bool)(this["ShouldUpgrade"]));
-            }
-            set {
-                this["ShouldUpgrade"] = value;
             }
         }
     }

--- a/Luxa4Slack.Tray/Properties/Settings.settings
+++ b/Luxa4Slack.Tray/Properties/Settings.settings
@@ -5,14 +5,17 @@
     <Setting Name="Token" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="ShowUnreadMessages" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
-    </Setting>
-    <Setting Name="ShowUnreadMentions" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
-    </Setting>
     <Setting Name="ShouldUpgrade" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="ShowStatus" Type="System.String" Scope="User">
+      <Value Profile="(Default)">true</Value>
+    </Setting>
+    <Setting Name="ShowUnreadMessages" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="ShowUnreadMentions" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/Luxa4Slack.Tray/app.config
+++ b/Luxa4Slack.Tray/app.config
@@ -26,14 +26,17 @@
       <setting name="Token" serializeAs="String">
         <value />
       </setting>
-      <setting name="ShowUnreadMessages" serializeAs="String">
-        <value>True</value>
-      </setting>
-      <setting name="ShowUnreadMentions" serializeAs="String">
-        <value>True</value>
-      </setting>
       <setting name="ShouldUpgrade" serializeAs="String">
         <value>True</value>
+      </setting>
+      <setting name="ShowStatus" serializeAs="String">
+        <value>true</value>
+      </setting>
+      <setting name="ShowUnreadMessages" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="ShowUnreadMentions" serializeAs="String">
+        <value>False</value>
       </setting>
     </CG.Luxa4Slack.Tray.Properties.Settings>
   </userSettings>

--- a/Luxa4Slack/Luxa4Slack.cs
+++ b/Luxa4Slack/Luxa4Slack.cs
@@ -8,9 +8,10 @@
   {
     private const int DelayBeforeUpdate = 2000;
     
-    private readonly string slackToken;
+    public readonly string slackToken;
     private readonly bool showUnreadMentions;
     private readonly bool showUnreadMessages;
+    private readonly bool showStatus;
 
     private LuxaforClient luxaforClient;
     private SlackNotificationAgent slackAgent;
@@ -18,7 +19,7 @@
     private Task updateTask;
     private int previousWeight;
 
-    public Luxa4Slack(string slackToken, bool showUnreadMentions, bool showUnreadMessages)
+    public Luxa4Slack(string slackToken, bool showUnreadMentions, bool showUnreadMessages, bool showStatus)
     {
       if (slackToken == null)
       {
@@ -28,6 +29,7 @@
       this.slackToken = slackToken;
       this.showUnreadMentions = showUnreadMentions;
       this.showUnreadMessages = showUnreadMessages;
+      this.showStatus = showStatus;
     }
 
     public event Action LuxaforFailure;
@@ -110,7 +112,7 @@
       int weight = 0;
       weight += this.showUnreadMentions && this.slackAgent.HasUnreadMentions ? 2 : 0;
       weight += this.showUnreadMessages && this.slackAgent.HasUnreadMessages ? 1 : 0;
-
+      
       return weight;
     }
 
@@ -119,11 +121,19 @@
       bool result;
       if (this.showUnreadMentions && this.slackAgent.HasUnreadMentions)
       {
-        result = this.luxaforClient.Set(LuxaforClient.Colors.Red);
+        result = this.luxaforClient.Set(LuxaforClient.Colors.Cyan);
       }
       else if (this.showUnreadMessages && this.slackAgent.HasUnreadMessages)
       {
         result = this.luxaforClient.Set(LuxaforClient.Colors.Blue);
+      }
+      else if (this.showStatus && this.slackAgent.isAway)
+      {
+        result = this.luxaforClient.Set(LuxaforClient.Colors.Red);
+      }
+      else if (this.showStatus && this.slackAgent.isAway == false)
+      {
+        result = this.luxaforClient.Set(LuxaforClient.Colors.Green);
       }
       else
       {

--- a/Luxa4Slack/Luxa4Slack.csproj
+++ b/Luxa4Slack/Luxa4Slack.csproj
@@ -71,6 +71,7 @@
     </Compile>
     <Compile Include="ChannelInfo.cs" />
     <Compile Include="ChannelsInfo.cs" />
+    <Compile Include="SlackClient.cs" />
     <Compile Include="IRawMessage.cs" />
     <Compile Include="JsonRawConverter.cs" />
     <Compile Include="Luxa4Slack.cs" />

--- a/Luxa4Slack/LuxaforClient.cs
+++ b/Luxa4Slack/LuxaforClient.cs
@@ -21,7 +21,9 @@
       White,
       Red,
       Green,
-      Blue
+      Yellow,
+      Blue,
+      Cyan
     }
 
     private readonly Dictionary<Colors, Color> colorsMapping = new Dictionary<Colors, Color>
@@ -30,7 +32,9 @@
                                                           { Colors.White, new Color(255, 255, 255) },
                                                           { Colors.Red, new Color(255, 0, 0) },
                                                           { Colors.Green, new Color(0, 255, 0) },
+                                                          { Colors.Yellow, new Color(255, 255, 0) },
                                                           { Colors.Blue, new Color(0, 0, 255) },
+                                                          { Colors.Cyan, new Color(0, 255, 255) },
                                                         };
 
     private IDevice device;
@@ -75,7 +79,7 @@
     {
       this.logger.Debug("Test device");
 
-      bool result = this.Set(Colors.Green);
+      bool result = this.Set(Colors.White);
       Thread.Sleep(200);
 
       return result && this.Set(Colors.None);

--- a/Luxa4Slack/SlackClient.cs
+++ b/Luxa4Slack/SlackClient.cs
@@ -1,0 +1,59 @@
+﻿namespace CG.Luxa4Slack
+{
+
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+  using System.Text;
+  using System.Net.Http;
+  using System.Threading.Tasks;
+
+  using Newtonsoft.Json;
+
+
+  using NLog;
+
+  public class SlackClient
+  {
+    private readonly Uri _webhookUrl;
+    private readonly HttpClient _httpClient = new HttpClient();
+    protected readonly ILogger Logger = LogManager.GetLogger("Slack");
+
+    public SlackClient(Uri webhookUrl)
+    {
+      _webhookUrl = webhookUrl;
+    }
+
+    public async Task<HttpResponseMessage> SendMessageAsync(string message,
+        string channel = null, string username = null)
+    {
+      var payload = new
+      {
+        text = message,
+        channel,
+        username,
+      };
+      var serializedPayload = JsonConvert.SerializeObject(payload);
+      var response = await _httpClient.PostAsync(_webhookUrl,
+          new StringContent(serializedPayload, Encoding.UTF8, "application/json"));
+
+      return response;
+    }
+
+    public async Task<HttpResponseMessage> Presence_Sub(string mytoken)
+    {
+      var payload = new
+      {
+        token = mytoken,
+        presence_sub = 1,
+      };
+      var serializedPayload = JsonConvert.SerializeObject(payload);
+      this.Logger.Debug($"Subscribe response {serializedPayload}");
+      var response = await _httpClient.PostAsync(_webhookUrl,
+          new StringContent(serializedPayload, Encoding.UTF8, "application/json"));
+
+      return response;
+    }
+
+  }
+}

--- a/Luxa4Slack/SlackNotificationAgent.cs
+++ b/Luxa4Slack/SlackNotificationAgent.cs
@@ -4,11 +4,15 @@
   using System.Collections.Generic;
   using System.Linq;
   using System.Threading;
+  using System.Threading.Tasks;
 
   using NLog;
 
   using SlackAPI;
   using SlackAPI.WebSocketMessages;
+  using SlackAPI.RPCMessages;
+
+  //using SlackCli
 
   internal class SlackNotificationAgent : IDisposable
   {
@@ -21,6 +25,9 @@
     private readonly string token;
     private readonly ChannelsInfo channelsInfo = new ChannelsInfo();
     private readonly List<string> highlightWords = new List<string>();
+    private UserGetPresenceResponse UserPresence = new UserGetPresenceResponse();
+
+    // private readonly Enum PresenceResponse = new PresenceResponse();
 
     private delegate void GetHistoryHandler(Action<MessageHistory> callback, Channel groupInfo, DateTime? latest, DateTime? oldest, int? count);
 
@@ -37,6 +44,8 @@
 
     public bool HasUnreadMentions { get; private set; }
 
+    public bool isAway { get; private set; }
+    
     public virtual bool Initialize()
     {
       this.Logger.Debug($"Initialize connection using token : {this.token}");
@@ -68,11 +77,27 @@
         this.FetchInitialMessages();
         this.UpdateStatus();
 
+        // Bind the Presence change
+        this.Client.BindCallback<PresenceChange>(x =>
+        {
+          this.Logger.Debug("Change event!");
+          this.UpdateStatus();
+        });
+
+        this.Client.BindCallback<ManualPresenceChange>(x =>
+        {
+          this.Logger.Debug("Manual change event!");
+          this.UpdateStatus();
+        });
+
         // Listen specific messages
         this.Client.BindCallback<ImMarked>(this.OnImMarked);
         this.Client.BindCallback<ChannelMarked>(this.OnChannelMarked);
         this.Client.BindCallback<GroupMarked>(this.OnChannelMarked);
         this.Client.BindCallback<NewMessage>(this.OnMessageReceived);
+
+        // Subscribe to Presence events
+        this.PresenceSubscribe(token);
 
         return true;
       }
@@ -90,6 +115,10 @@
       this.Client.UnbindCallback<ChannelMarked>(this.OnChannelMarked);
       this.Client.UnbindCallback<GroupMarked>(this.OnChannelMarked);
       this.Client.UnbindCallback<NewMessage>(this.OnMessageReceived);
+      this.Client.UnbindCallback<PresenceChange>(x =>
+      {
+        this.UpdatePresenceStatus();
+      });
 
       this.Client.CloseSocket();
     }
@@ -104,11 +133,67 @@
       this.HasUnreadMessages = this.channelsInfo.Any(x => x.Value.UnreadMessage > 0);
       this.HasUnreadMentions = this.channelsInfo.Any(x => x.Value.UnreadMention > 0);
 
+      this.Client.GetPresence(
+        x =>
+        {
+          this.UserPresence = x;
+          this.UpdatePresenceStatus();
+        }
+        , this.Client.MySelf.id);
+
+      
+
+      //this.Client.HandlePresence()
+
       this.Logger.Debug($"HasUnreadMention: {this.HasUnreadMentions}");
       this.Logger.Debug($"HasUnreadMessage: {this.HasUnreadMessages}");
 
       this.Changed?.Invoke();
     }
+
+    protected void UpdatePresenceStatus()
+    {
+      this.Logger.Debug($"User is currently {UserPresence.presence.ToString()}");
+
+      if (UserPresence.presence.ToString() == "away")
+      {
+        this.isAway = true;
+      }
+      else
+      {
+        // Going to assume default of being there.
+        this.isAway = false;
+      }
+
+      
+      this.Changed?.Invoke();
+      
+    }
+
+    protected void OnPresenceChange()
+    {
+      this.Client.GetPresence(
+        x =>
+        {
+          this.UserPresence = x;
+          this.UpdatePresenceStatus();
+        }
+        , this.Client.MySelf.id);
+    }
+
+
+    protected async Task PresenceSubscribe(string token)
+    {
+      var webhookUrl = new Uri("https://slack.com/api/rtm.connect");
+      var slackClient = new SlackClient(webhookUrl);
+      this.Logger.Debug("Calling URL");
+      
+      var response = await slackClient.Presence_Sub(token) ;
+      var isValid = response.IsSuccessStatusCode ? "valid" : "invalid";
+      this.Logger.Debug($"Subscribe response {isValid}");
+      
+    }
+
 
     protected void ClearChannelsInfo()
     {
@@ -253,6 +338,13 @@
         }
       }
     }
+
+    private void PresenceSub()
+    {
+
+
+    }
+
 
     private void OnImMarked(ImMarked message)
     {

--- a/Luxa4Slack/SlackSocketExtraMessages.cs
+++ b/Luxa4Slack/SlackSocketExtraMessages.cs
@@ -16,4 +16,27 @@
   public class GroupMarked : ChannelMarked
   {
   }
+
+  /*
+  [SlackSocketRouting("manual_presence_change", null)]
+  public class ManualPresenceChange : SlackSocketMessage
+  {
+    public string user;
+    public Presence presence;
+
+  }
+  */
+
 }
+
+namespace SlackAPI.WebSocketMessages
+{
+  [SlackSocketRouting("manual_presence_change", null)]
+  public class ManualPresenceChange : SlackSocketMessage
+  {
+    public string user;
+    public Presence presence;
+
+  }
+}
+


### PR DESCRIPTION
Wanted to have the ability to change the color of a Luxafor based on your available/away status, we use it in the office to (automatically) show if you're available or not.

Added a new flag showStatus which is tied to that, while leaving old behaviour intact (mainly updated colors and added new colors). 