### PR TITLE
Replace retired *History() methods with GetConversationsHistory()

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/SlackAPI"]
+	path = vendor/SlackAPI
+	url = https://github.com/Inumedia/SlackAPI.git

--- a/Luxa4Slack.sln
+++ b/Luxa4Slack.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Luxa4Slack.OAuth.AzureFunct
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "build\_build.csproj", "{C8AD61D9-1BAA-4B0E-A980-AC7CBF60C29C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlackAPI", "vendor\SlackAPI\SlackAPI\SlackAPI.csproj", "{72DA7C19-43C1-4829-97BA-34D85E83290E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +45,10 @@ Global
 		{97C3955F-215E-4E71-942F-7BE2A9749A59}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97C3955F-215E-4E71-942F-7BE2A9749A59}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97C3955F-215E-4E71-942F-7BE2A9749A59}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72DA7C19-43C1-4829-97BA-34D85E83290E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72DA7C19-43C1-4829-97BA-34D85E83290E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72DA7C19-43C1-4829-97BA-34D85E83290E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72DA7C19-43C1-4829-97BA-34D85E83290E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,13 @@
 image:
   - Visual Studio 2019
 
+clone_script:
+  - cmd: >-
+      git clone -q --branch=%APPVEYOR_REPO_BRANCH% https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
+      && cd %APPVEYOR_BUILD_FOLDER%
+      && git checkout -qf %APPVEYOR_REPO_COMMIT%
+      && git submodule update --init --recursive
+
 build_script:
   - ps: .\build.ps1 Pack BuildInstaller
 

--- a/src/Luxa4Slack/Luxa4Slack.csproj
+++ b/src/Luxa4Slack/Luxa4Slack.csproj
@@ -50,10 +50,6 @@
       <HintPath>..\..\packages\NLog.4.6.8\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SlackAPI, Version=1.2.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\SlackAPI.1.2.0-pullrequest0016\lib\net45\SlackAPI.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -110,6 +106,12 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\vendor\SlackAPI\SlackAPI\SlackAPI.csproj">
+      <Project>{72da7c19-43c1-4829-97ba-34d85e83290e}</Project>
+      <Name>SlackAPI</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/Luxa4Slack/MessageHandlers/ChannelHandlerBase.cs
+++ b/src/Luxa4Slack/MessageHandlers/ChannelHandlerBase.cs
@@ -19,10 +19,8 @@
       this.Client.BindCallback<TMessage>(this.OnChannelMarked);
 
       this.Logger.Debug("Fetch initial messages");
-      foreach (var channel in this.GetChannels())
-      {
-        this.UpdateChannelInfo(channel);
-      }
+
+      this.RunParallel(this.GetChannels(), this.UpdateChannelInfo);
     }
 
     public override void Dispose()

--- a/src/Luxa4Slack/MessageHandlers/Channelhandler.cs
+++ b/src/Luxa4Slack/MessageHandlers/Channelhandler.cs
@@ -23,7 +23,7 @@
       return this.Client.ChannelLookup[message.channel];
     }
 
-    protected override GetHistoryHandler HistoryMethod => this.Client.GetChannelHistory;
+    protected override GetHistoryHandler HistoryMethod => this.Client.GetConversationsHistory;
 
     protected override bool ShouldMonitor(string id)
     {

--- a/src/Luxa4Slack/MessageHandlers/GroupHandler.cs
+++ b/src/Luxa4Slack/MessageHandlers/GroupHandler.cs
@@ -22,7 +22,7 @@
       return this.Client.GroupLookup[message.channel];
     }
 
-    protected override GetHistoryHandler HistoryMethod => this.Client.GetGroupHistory;
+    protected override GetHistoryHandler HistoryMethod => this.Client.GetConversationsHistory;
 
     protected override bool ShouldMonitor(string id)
     {

--- a/src/Luxa4Slack/MessageHandlers/MessageHandlerBase.cs
+++ b/src/Luxa4Slack/MessageHandlers/MessageHandlerBase.cs
@@ -1,7 +1,9 @@
 ﻿namespace CG.Luxa4Slack.MessageHandlers
 {
   using System;
+  using System.Collections.Generic;
   using System.Linq;
+  using System.Threading.Tasks;
   using NLog;
   using SlackAPI;
   using SlackAPI.WebSocketMessages;
@@ -9,6 +11,8 @@
   internal abstract class MessageHandlerBase : IDisposable
   {
     protected const int HistoryItemsToFetch = 50;
+
+    private const int MaxDegreeOfParallelism = 8;
 
     protected readonly SlackSocketClient Client;
 
@@ -64,6 +68,15 @@
     }
 
     protected abstract bool ShouldMonitor(string id);
+
+    protected void RunParallel<T>(IEnumerable<T> source, Action<T> callback)
+    {
+      Parallel.ForEach(
+        source,
+        new ParallelOptions { MaxDegreeOfParallelism = MaxDegreeOfParallelism },
+        callback
+      );
+    }
 
     private void OnMessageReceived(NewMessage message)
     {

--- a/src/Luxa4Slack/packages.config
+++ b/src/Luxa4Slack/packages.config
@@ -5,7 +5,6 @@
   <package id="LuxaforSharp" version="2.0.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
   <package id="NLog" version="4.6.8" targetFramework="net452" />
-  <package id="SlackAPI" version="1.2.0-pullrequest0016" targetFramework="net452" />
   <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net452" />


### PR DESCRIPTION
Closes #21 

Some Slack API endpoints used by Luxa4Slack were retired and broke the application (https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api)

Endpoints are replaced with new Conversation API endpoints